### PR TITLE
feat(ws): broadcast room creation to other peers

### DIFF
--- a/src/server/src/chat.rs
+++ b/src/server/src/chat.rs
@@ -50,7 +50,7 @@ pub enum ClientMessage {
     ListRooms,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(tag = "type")]
 pub enum ServerMessage {
     RoomCreated { room: Room },

--- a/src/server/src/ws.rs
+++ b/src/server/src/ws.rs
@@ -9,7 +9,7 @@ use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::{Mutex, mpsc};
 use tokio_tungstenite::accept_async;
 use tokio_tungstenite::tungstenite::Message;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 use uuid::Uuid;
 
 use crate::chat::{ChatMessage, ClientMessage, Room, ServerMessage};
@@ -128,19 +128,20 @@ impl WebSocket {
 
                 node.rooms.insert(room.id, room.clone());
 
-                if let Some(tx) = node.connections.get(&addr) {
-                    if let Err(err) = tx.send(ServerMessage::RoomCreated { room: room.clone() }) {
-                        error!(%addr, ?err, "Failed to send RoomCreated message");
+                // Drop `node` lock before sending messages to avoid deadlocks
+                let conns: Vec<_> = node
+                    .connections
+                    .iter()
+                    .map(|(addr, tx)| (*addr, tx.clone()))
+                    .collect();
+                drop(node);
+
+                let msg = ServerMessage::RoomCreated { room };
+
+                for (conn, tx) in conns.iter() {
+                    if let Err(err) = tx.send(msg.clone()) {
+                        warn!(?err, ?conn, "Failed to send RoomCreated message");
                     }
-
-                    let mut connections = node.connections.clone();
-                    connections.remove(&addr);
-
-                    tokio::spawn(async move {
-                        for tx in connections.values() {
-                            let _ = tx.send(ServerMessage::RoomCreated { room: room.clone() });
-                        }
-                    });
                 }
 
                 Ok(())


### PR DESCRIPTION
This pull request updates the logic for broadcasting the `RoomCreated` message to all WebSocket connections except the one that initiated the room creation. The main change is to ensure that all other connected clients are notified asynchronously when a new room is created.

**WebSocket room creation and notification improvements:**

* Refactored the logic in `WebSocket` so that after sending the `RoomCreated` message to the initiating client, the message is now broadcast asynchronously to all other connected clients using a cloned list of connections, excluding the initiator.

## Screenshot

<img width="1201" height="854" alt="Screenshot 2025-11-26 at 00 55 12" src="https://github.com/user-attachments/assets/6b8b7dbd-8cab-4df5-b59e-b6dd61c013f7" />

